### PR TITLE
Sync changes from internal dev branch.

### DIFF
--- a/betocq/d2d_performance_test_base.py
+++ b/betocq/d2d_performance_test_base.py
@@ -403,7 +403,7 @@ class D2dPerformanceTestBase(nc_base_test.NCBaseTestClass, abc.ABC):
           active_snippet.transfer_file(
               self._get_transfer_file_size(),
               self._get_file_transfer_timeout(),
-              self.test_parameters.payload_type,
+              nc_constants.PayloadType(self.test_parameters.payload_type),
               self.test_parameters.payload_file_num,
           )
       )

--- a/betocq/d2d_performance_test_base.py
+++ b/betocq/d2d_performance_test_base.py
@@ -205,6 +205,15 @@ class D2dPerformanceTestBase(nc_base_test.NCBaseTestClass, abc.ABC):
             min_throughput_mbyte_per_sec
             * nc_constants.MCC_THROUGHPUT_MULTIPLIER
         )
+        # MCC hotspot has even lower throughput due to sync issue with STA.
+        if (
+            self._upgrade_medium_under_test
+            == nc_constants.NearbyMedium.UPGRADE_TO_WIFIHOTSPOT
+        ):
+          min_throughput_mbyte_per_sec = (
+              min_throughput_mbyte_per_sec
+              * nc_constants.MCC_HOTSPOT_THROUGHPUT_MULTIPLIER
+          )
 
       nc_min_throughput_mbyte_per_sec = (
           min_throughput_mbyte_per_sec

--- a/betocq/d2d_performance_test_base.py
+++ b/betocq/d2d_performance_test_base.py
@@ -395,6 +395,7 @@ class D2dPerformanceTestBase(nc_base_test.NCBaseTestClass, abc.ABC):
               self._get_transfer_file_size(),
               self._get_file_transfer_timeout(),
               self.test_parameters.payload_type,
+              self.test_parameters.payload_file_num,
           )
       )
 
@@ -578,10 +579,12 @@ class D2dPerformanceTestBase(nc_base_test.NCBaseTestClass, abc.ABC):
     return ssid_advertiser
 
   def _get_transfer_file_size(self) -> int:
-    return nc_constants.TRANSFER_FILE_SIZE_500MB
+    return self.test_parameters.payload_file_size_kbyte
 
   def _get_file_transfer_timeout(self) -> datetime.timedelta:
-    return nc_constants.WIFI_500M_PAYLOAD_TRANSFER_TIMEOUT
+    return datetime.timedelta(
+        seconds=self.test_parameters.payload_transfer_timeout_sec
+    )
 
   def _get_success_rate_target(self) -> float:
     return nc_constants.SUCCESS_RATE_TARGET

--- a/betocq/d2d_performance_test_base.py
+++ b/betocq/d2d_performance_test_base.py
@@ -637,6 +637,10 @@ class D2dPerformanceTestBase(nc_base_test.NCBaseTestClass, abc.ABC):
         f'{round(self._current_test_result.quality_info.connection_latency.total_seconds(), 1)}'
     )
     transfer_quality_info.append(
+        'connection_medium: '
+        f'{self._current_test_result.quality_info.get_connection_medium_name()}'
+    )
+    transfer_quality_info.append(
         'upgrade_latency: '
         f'{round(self._current_test_result.quality_info.medium_upgrade_latency.total_seconds(), 1)}'
     )

--- a/betocq/directed_tests/mcc_5g_hotspot_dfs_5g_sta_test.py
+++ b/betocq/directed_tests/mcc_5g_hotspot_dfs_5g_sta_test.py
@@ -28,7 +28,7 @@ The device requirements:
 The AP requirements:
   wifi channel: 52 (5260)
 """
-
+import datetime
 import logging
 
 from mobly  import base_test
@@ -66,6 +66,18 @@ class Mcc5gHotspotDfs5gStaTest(
         wifi_ssid=self.test_parameters.wifi_dfs_5g_ssid,
         wifi_password=self.test_parameters.wifi_dfs_5g_password,
     )
+
+  # @typing.override
+  def _get_transfer_file_size(self) -> int:
+    return nc_constants.TRANSFER_FILE_SIZE_100MB
+
+  # @typing.override
+  def _get_file_transfer_timeout(self) -> datetime.timedelta:
+    return nc_constants.WIFI_100M_PAYLOAD_TRANSFER_TIMEOUT
+
+  # @typing.override
+  def _get_success_rate_target(self) -> float:
+    return nc_constants.MCC_HOTSPOT_TEST_SUCCESS_RATE_TARGET
 
   def _get_file_transfer_failure_tip(self) -> str:
     return (

--- a/betocq/function_tests/fixed_wifi_medium_function_test_actor.py
+++ b/betocq/function_tests/fixed_wifi_medium_function_test_actor.py
@@ -69,7 +69,7 @@ class FixedWifiMediumFunctionTestActor(
       self._test_result.file_transfer_throughput_kbps = (
           nearby_snippet.transfer_file(
               nc_constants.TRANSFER_FILE_SIZE_FUNC_TEST_KB,
-              nc_constants.TRANSFER_TIMEOUT_FUNC_TEST_SEC,
+              nc_constants.TRANSFER_TIMEOUT_FUNC_TEST,
               payload_type,
               nc_constants.TRANSFER_FILE_NUM_FUNC_TEST))
     finally:

--- a/betocq/gms/hermetic_overrides_partner.py
+++ b/betocq/gms/hermetic_overrides_partner.py
@@ -1,0 +1,107 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Utilities for loading hermetic overrides on devices."""
+
+import io
+import os
+
+from mobly.controllers import android_device
+from mobly.controllers.android_device_lib import apk_utils
+
+
+_GMS_PACKAGE = 'com.google.android.gms'
+
+OVERRIDES_PATH = '/sdcard/overrides.txt'
+SCRIPT_PATH = '/sdcard/setup_flags.sh'
+
+
+def _create_setup_script(
+    script_template: str,
+    overrides_source: str = OVERRIDES_PATH,
+    merge_overrides: bool = False,
+    package: str = _GMS_PACKAGE,
+) -> str:
+  return (
+      script_template.replace(r'${ARG_APP_PACKAGE_NAME}', package)
+      .replace(r'${ARG_HERMETIC_OVERRIDES_SOURCE_DEVICE}', overrides_source)
+      .replace(r'${ARG_MERGE_EXISTING_OVERRIDES}', str(merge_overrides))
+  )
+
+
+def _run_setup_script(
+    device: android_device.AndroidDevice, script: str, output_path: str
+) -> str:
+  """Runs the overrides script on the device and returns the output."""
+  host_file = os.path.join(output_path, 'setup_flags.sh')
+  with open(host_file, 'w') as f:
+    f.write(script)
+  device.adb.push([host_file, SCRIPT_PATH], timeout=120)
+  device.adb.shell(f'chmod +x {SCRIPT_PATH}', shell=True)
+  # For backwards compatibility on very old devices, the overrides script writes
+  # to stderr rather than stdout (which is always empty), even when there are
+  # no errors.
+  stderr = io.BytesIO()
+  device.adb.shell(f'sh {SCRIPT_PATH}', stderr=stderr)
+  stderr.seek(0)
+  return stderr.read().decode('utf-8')
+
+
+def install_hermetic_overrides(
+    device: android_device.AndroidDevice,
+    hermetic_overrides_file: str,
+    output_path: str,
+    package: str,
+    setup_template: str,
+    merge_with_existing_overrides: bool = False,
+) -> None:
+  """Installs hermetic overrides on device for the given package.
+
+  You MUST stop the process for the given package after calling this function
+  to see the effect of the overrides.
+
+  Preconditions:
+    The package must be already installed on the device.
+
+  Note that if you are trying to set flags for GMS modules, you should use
+  `com.google.android.gms` rather than the Chimera package.
+
+  Args:
+    device: The device of interest.
+    hermetic_overrides_file: The file path to the hermetic overrides file.
+    output_path: Path where debug data will be written.
+    package: The package name for the app containing the flags to be overridden.
+    setup_template: The raw overrides setup script template.
+    merge_with_existing_overrides: Whether to merge the overrides with any
+      existing overrides on the device. If `False`, the existing overrides will
+      be completely replaced.
+  """
+  if package.startswith(_GMS_PACKAGE) and package != _GMS_PACKAGE:
+    raise ValueError(f'GMS modules should use package {_GMS_PACKAGE}')
+  if not apk_utils.is_apk_installed(device, package):
+    raise ValueError(f'Package {package} is not installed on device')
+
+  device.log.info(
+      'Existing overrides will be'
+      f' {"merged" if merge_with_existing_overrides else "replaced"}.',
+  )
+  device.adb.root()
+  device.adb.push([hermetic_overrides_file, OVERRIDES_PATH])
+  setup_script = _create_setup_script(
+      setup_template,
+      package=package,
+      merge_overrides=merge_with_existing_overrides,
+  )
+  result = _run_setup_script(device, setup_script, output_path)
+  device.log.info('Override script result:\n%s', result)

--- a/betocq/nc_base_test.py
+++ b/betocq/nc_base_test.py
@@ -52,7 +52,6 @@ class NCBaseTestClass(base_test.BaseTestClass):
   """The Base of Nearby Connection E2E tests."""
 
   _run_identifier_is_set = False
-  _committed_ph_flags_is_set = False
 
   def __init__(self, configs):
     super().__init__(configs)
@@ -84,8 +83,6 @@ class NCBaseTestClass(base_test.BaseTestClass):
   def setup_class(self) -> None:
     self._setup_openwrt_wifi()
     self.ads = self.register_controller(android_device, min_number=2)
-    # record the flags only for the first device
-    self._set_committed_ph_flags(self.ads[0])
     for ad in self.ads:
       if hasattr(ad, 'dimensions') and 'role' in ad.dimensions:
         ad.role = ad.dimensions['role']
@@ -177,25 +174,6 @@ class NCBaseTestClass(base_test.BaseTestClass):
         }
     })
     NCBaseTestClass._run_identifier_is_set = True
-
-  def _set_committed_ph_flags(self, ad) -> None:
-    """Set a committed_ph_flags property describing the committed P/H flags.
-
-    This property is only set once, even if multiple test classes are run as
-    part of a test suite.
-
-    Args:
-      ad: AndroidDevice, Mobly Android Device.
-    """
-
-    if NCBaseTestClass._committed_ph_flags_is_set:
-      return
-
-    flags = setup_utils.get_committed_ph_flags(
-        ad, 'com.google.android.gms.nearby'
-    )
-    self.record_data({'properties': {'committed_ph_flags': flags}})
-    NCBaseTestClass._committed_ph_flags_is_set = True
 
   def _setup_openwrt_wifi(self):
     """Sets up the wifi connection with OpenWRT."""
@@ -319,20 +297,12 @@ class NCBaseTestClass(base_test.BaseTestClass):
 
     setup_utils.remove_disconnect_wifi_network(ad)
     setup_utils.enable_logs(ad)
-    setup_utils.disable_redaction(ad)
-    setup_utils.enable_wifi_aware(ad)
-    setup_utils.disable_wlan_deny_list(ad)
-    setup_utils.enable_instant_connection(
-        ad, self.test_parameters.enable_instant_connection
+    setup_utils.set_flags(
+        ad,
+        self.current_test_info.output_path,
+        self.test_parameters.enable_instant_connection,
+        self.test_parameters.enable_2g_ble_scan_throttling,
     )
-    setup_utils.disable_usb_medium(ad)
-    setup_utils.disable_op_mode_check(ad)
-
-    setup_utils.enable_ble_scan_throttling_during_2g_transfer(
-        ad, self.test_parameters.enable_2g_ble_scan_throttling
-    )
-    setup_utils.force_flag_sync(ad)
-    setup_utils.restart_gms(ad)
 
     setup_utils.set_country_code(
         ad, self._get_country_code(), self.test_parameters.force_telephony_cc
@@ -456,7 +426,7 @@ class NCBaseTestClass(base_test.BaseTestClass):
         ),
         f'max_num_streams: {ad.max_num_streams}',
         f'max_num_streams_dbs: {ad.max_num_streams_dbs}',
-        f'support_aware: {setup_utils.is_wifi_aware_available(ad)}'
+        f'support_aware: {setup_utils.is_wifi_aware_available(ad)}',
     ]
 
   def _get_test_summary_dict(self, test_result: str) -> dict[str, str]:

--- a/betocq/nc_base_test.py
+++ b/betocq/nc_base_test.py
@@ -27,6 +27,7 @@ from mobly import base_test
 from mobly import records
 from mobly import utils
 from mobly.controllers import android_device
+from mobly.controllers.android_device_lib import apk_utils
 from mobly.controllers.android_device_lib import errors
 from mobly.controllers.wifi import openwrt_device
 from mobly.controllers.wifi.lib import wifi_configs
@@ -275,7 +276,7 @@ class NCBaseTestClass(base_test.BaseTestClass):
     ad.debug_tag = ad.serial + '(' + ad.adb.getprop('ro.product.model') + ')'
     ad.log.info('try to install nearby_snippet_apk')
     if self._nearby_snippet_apk_path:
-      setup_utils.install_apk(ad, self._nearby_snippet_apk_path)
+      apk_utils.install(ad, self._nearby_snippet_apk_path)
     else:
       ad.log.warning(
           'nearby_snippet apk is not specified, '
@@ -290,7 +291,7 @@ class NCBaseTestClass(base_test.BaseTestClass):
     if self._requires_2_snippet_apks:
       ad.log.info('try to install nearby_snippet_2_apk')
       if self._nearby_snippet_2_apk_path:
-        setup_utils.install_apk(ad, self._nearby_snippet_2_apk_path)
+        apk_utils.install(ad, self._nearby_snippet_2_apk_path)
       else:
         ad.log.warning(
             'nearby_snippet_2 apk is not specified, '
@@ -304,7 +305,7 @@ class NCBaseTestClass(base_test.BaseTestClass):
     if self._requires_3p_snippet_apks:
       ad.log.info('try to install nearby_snippet_3p_apk')
       if self._nearby_snippet_3p_apk_path:
-        setup_utils.install_apk(ad, self._nearby_snippet_3p_apk_path)
+        apk_utils.install(ad, self._nearby_snippet_3p_apk_path)
       else:
         ad.log.warning(
             'nearby_snippet_3p apk is not specified, '

--- a/betocq/nc_base_test.py
+++ b/betocq/nc_base_test.py
@@ -325,6 +325,7 @@ class NCBaseTestClass(base_test.BaseTestClass):
         ad, self.test_parameters.enable_instant_connection
     )
     setup_utils.disable_usb_medium(ad)
+    setup_utils.disable_op_mode_check(ad)
 
     setup_utils.enable_ble_scan_throttling_during_2g_transfer(
         ad, self.test_parameters.enable_2g_ble_scan_throttling

--- a/betocq/nc_constants.py
+++ b/betocq/nc_constants.py
@@ -434,10 +434,13 @@ class ConnectionSetupQualityInfo:
   connection_latency: datetime.timedelta = UNSET_LATENCY
   medium_upgrade_latency: datetime.timedelta = UNSET_LATENCY
   medium_upgrade_expected: bool = False
+  connection_medium: NearbyConnectionMedium | None = None
   upgrade_medium: NearbyConnectionMedium | None = None
   medium_frequency: int = INVALID_INT
 
   def get_dict(self) -> dict[str, str]:
+    """The get dict representation of the quality info."""
+
     dict_repr = {
         'discovery': f'{round(self.discovery_latency.total_seconds(), 1)}s',
         'connection': f'{round(self.connection_latency.total_seconds(), 1)}s'
@@ -446,9 +449,16 @@ class ConnectionSetupQualityInfo:
       dict_repr['upgrade'] = (
           f'{round(self.medium_upgrade_latency.total_seconds(), 1)}s'
       )
+    if self.connection_medium is not None:
+      dict_repr['connection_medium'] = self.connection_medium.name
     if self.upgrade_medium:
       dict_repr['medium'] = self.upgrade_medium.name
     return dict_repr
+
+  def get_connection_medium_name(self) -> str:
+    if self.connection_medium is not None:
+      return self.connection_medium.name
+    return 'na'
 
   def get_medium_name(self) -> str:
     if self.upgrade_medium:

--- a/betocq/nc_constants.py
+++ b/betocq/nc_constants.py
@@ -25,6 +25,8 @@ BETOCQ_SUITE_NAME = 'BeToCQ'
 
 SUCCESS_RATE_TARGET = 0.98
 BLE_PERFORMANCE_TEST_SUCCESS_RATE_TARGET = 0.98
+# MCC hotspot test is more flaky than other MCC tests due to the sync issue.
+MCC_HOTSPOT_TEST_SUCCESS_RATE_TARGET = 0.90
 MCC_PERFORMANCE_TEST_COUNT = 100
 MCC_PERFORMANCE_TEST_MAX_CONSECUTIVE_ERROR = 5
 SCC_PERFORMANCE_TEST_COUNT = 10
@@ -54,6 +56,7 @@ SECOND_CONNECTION_RESULT_TIMEOUT = datetime.timedelta(seconds=25)
 CONNECTION_BANDWIDTH_CHANGED_TIMEOUT = datetime.timedelta(seconds=25)
 WIFI_1K_PAYLOAD_TRANSFER_TIMEOUT = datetime.timedelta(seconds=20)
 WIFI_2G_20M_PAYLOAD_TRANSFER_TIMEOUT = datetime.timedelta(seconds=20)
+WIFI_100M_PAYLOAD_TRANSFER_TIMEOUT = datetime.timedelta(seconds=100)
 WIFI_200M_PAYLOAD_TRANSFER_TIMEOUT = datetime.timedelta(seconds=100)
 WIFI_500M_PAYLOAD_TRANSFER_TIMEOUT = datetime.timedelta(seconds=250)
 WIFI_STA_CONNECTING_TIME_OUT = datetime.timedelta(seconds=25)
@@ -64,6 +67,8 @@ MAX_PHY_RATE_PER_STREAM_AC_40_MBPS = 200
 MAX_PHY_RATE_PER_STREAM_N_20_MBPS = 72
 
 MCC_THROUGHPUT_MULTIPLIER = 0.25
+# MCC hotspot has lower throughput due to synchronization issue with STA.
+MCC_HOTSPOT_THROUGHPUT_MULTIPLIER = 0.2
 MAX_PHY_RATE_TO_MIN_THROUGHPUT_RATIO_5G = 0.37
 IPERF_TO_NC_THROUGHPUT_RATIO = 0.8
 MAX_PHY_RATE_TO_MIN_THROUGHPUT_RATIO_2G = 0.10
@@ -92,6 +97,7 @@ RSSI_HIGH_THRESHOLD = -15
 
 TRANSFER_FILE_SIZE_500MB = 500 * 1024  # kB
 TRANSFER_FILE_SIZE_200MB = 200 * 1024  # kB
+TRANSFER_FILE_SIZE_100MB = 100 * 1024  # kB
 TRANSFER_FILE_SIZE_20MB = 20 * 1024  # kB
 TRANSFER_FILE_SIZE_1MB = 1024  # kB
 TRANSFER_FILE_SIZE_500KB = 512  # kB
@@ -188,6 +194,7 @@ class TestParameters:
   skip_bug_report: bool = False
   force_telephony_cc: bool = False
   bypass_airplane_mode_toggling: bool = False
+  run_mcc_hotspot_test: bool = True
 
   @classmethod
   def from_user_params(

--- a/betocq/nc_constants.py
+++ b/betocq/nc_constants.py
@@ -102,7 +102,7 @@ TRANSFER_FILE_SIZE_10KB = 10  # kB
 TRANSFER_FILE_SIZE_FUNC_TEST_KB = 1
 TRANSFER_FILE_NUM_DEFAULT = 1
 TRANSFER_FILE_NUM_FUNC_TEST = 100
-TRANSFER_TIMEOUT_FUNC_TEST_SEC = datetime.timedelta(seconds=100)
+TRANSFER_TIMEOUT_FUNC_TEST = datetime.timedelta(seconds=100)
 
 TARGET_CUJ_QUICK_START = 'quick_start'
 TARGET_CUJ_NEARBY_CONNECTIONS_FUNCTION = 'nearby_connections_function'
@@ -158,6 +158,11 @@ class TestParameters:
   disconnect_bt_after_test: bool = False
   disconnect_wifi_after_test: bool = False
   payload_type: PayloadType = PayloadType.FILE
+  payload_file_num: int = 1
+  payload_file_size_kbyte: int = TRANSFER_FILE_SIZE_500MB
+  payload_transfer_timeout_sec: int = int(
+      WIFI_500M_PAYLOAD_TRANSFER_TIMEOUT.total_seconds()
+  )
   allow_unrooted_device: bool = False
   keep_alive_timeout_ms: int = KEEP_ALIVE_TIMEOUT_WIFI_MS
   keep_alive_interval_ms: int = KEEP_ALIVE_INTERVAL_WIFI_MS

--- a/betocq/nc_constants.py
+++ b/betocq/nc_constants.py
@@ -397,7 +397,8 @@ COMMON_WFD_UPGRADE_FAILURE_REASONS = '\n'.join([
 MEDIUM_UPGRADE_FAIL_TRIAGE_TIPS: dict[NearbyMedium, str] = {
     NearbyMedium.WIFILAN_ONLY: (
         ' WLAN, check if AP blocks the mDNS traffic. Check if STA is connected'
-        ' to AP during WiFi upgrade.'
+        ' to AP during WiFi upgrade. For the sporadic upgrade failure, try to'
+        ' disable WiFi power saving and check if the failure is gone.'
     ),
     NearbyMedium.UPGRADE_TO_WIFIHOTSPOT: (
         ' HOTSPOT, check the related wifip2p and NearbyConnections logs to see'

--- a/betocq/nearby_connection_wrapper.py
+++ b/betocq/nearby_connection_wrapper.py
@@ -441,10 +441,11 @@ class NearbyConnectionWrapper:
           timeout=timeout.total_seconds(),
       )
       tx_id = tx_transfer_event.data['update']['payloadId']
-      rx_id1 = rx_received_event.data['payload']['id']
-      rx_id2 = rx_transfer_event.data['update']['payloadId']
-      asserts.assert_equal(tx_id, rx_id1)
-      asserts.assert_equal(tx_id, rx_id2)
+      rx_id_payload_received = rx_received_event.data['payload']['id']
+      rx_id_transfer_update = rx_transfer_event.data['update']['payloadId']
+      if payload_type == nc_constants.PayloadType.FILE:
+        asserts.assert_equal(tx_id, rx_id_payload_received)
+        asserts.assert_equal(tx_id, rx_id_transfer_update)
       if tx_id == last_payload_id:
         transfer_time_s = datetime.timedelta(
             microseconds=tx_transfer_event.data['transferTimeNs']

--- a/betocq/resources.py
+++ b/betocq/resources.py
@@ -1,0 +1,32 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Wrapper API for accessing `data` resources."""
+
+from importlib.resources import files
+
+
+def GetResourceFilename(name: str) -> str:
+  """Get the file path of the named resource.
+
+  Args:
+    name: The name of the resource.
+
+  Returns:
+    The local file path of the named resource.
+  """
+  file_path = str(files('betocq.synced_resource_data').joinpath(name))
+  if not os.path.isfile(file_path):
+    raise ValueError(f'Resource {name} does not exist.')
+  return file_path

--- a/betocq/setup_utils.py
+++ b/betocq/setup_utils.py
@@ -458,6 +458,16 @@ def disable_usb_medium(ad: android_device.AndroidDevice) -> None:
   check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
 
 
+def disable_op_mode_check(ad: android_device.AndroidDevice) -> None:
+  """Disable get_usable_channel() op mode check on the given device."""
+  pname = 'com.google.android.gms.nearby'
+  flag_name = 'connections_check_op_mode_for_usable_channels'
+  flag_type = 'boolean'
+  flag_value = 'false'
+
+  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
+
+
 def enable_ble_scan_throttling_during_2g_transfer(
     ad: android_device.AndroidDevice, enable_ble_scan_throttling: bool = False
 ) -> None:

--- a/betocq/setup_utils.py
+++ b/betocq/setup_utils.py
@@ -440,6 +440,9 @@ def enable_instant_connection(
 
   check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
 
+  flag_name = 'connections_support_instant_connection_sender'
+  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
+
 
 def disable_wlan_deny_list(ad: android_device.AndroidDevice) -> None:
   """Disable wlan deny list on the given device."""

--- a/betocq/setup_utils.py
+++ b/betocq/setup_utils.py
@@ -520,11 +520,6 @@ def restart_gms(ad: android_device.AndroidDevice) -> None:
   ad.adb.shell('am force-stop com.google.android.gms')
 
 
-def install_apk(ad: android_device.AndroidDevice, apk_path: str) -> None:
-  """Installs the apk on the given device."""
-  ad.adb.install(['-r', '-g', '-t', apk_path])
-
-
 def disable_gms_auto_updates(ad: android_device.AndroidDevice) -> None:
   """Disable GMS auto updates on the given device."""
   if not ad.is_adb_root:

--- a/betocq/setup_utils.py
+++ b/betocq/setup_utils.py
@@ -116,6 +116,12 @@ def enable_logs(ad: android_device.AndroidDevice) -> None:
   ad.adb.shell('cmd wifi set-verbose-logging enabled')
 
   # Enable Bluetooth HCI logs.
+  if not ad.is_adb_root:
+    ad.log.info(
+        'Skipped setting Bluetooth HCI logs on device,'
+        'because we do not set Bluetooth HCI logs on unrooted phone.'
+    )
+    return
   ad.adb.shell('setprop persist.bluetooth.btsnooplogmode full')
 
   # Enable Bluetooth verbose logs.

--- a/betocq/setup_utils.py
+++ b/betocq/setup_utils.py
@@ -20,8 +20,18 @@ import time
 from mobly.controllers import android_device
 from mobly.controllers.android_device_lib import adb
 
+from betocq.gms import hermetic_overrides_partner
 from betocq import gms_auto_updates_util
 from betocq import nc_constants
+from betocq import resources
+
+_DEFAULT_OVERRIDES = '//wireless/android/platform/testing/bettertogether/betocq:default_overrides'
+_BLE_SCAN_THROTTLING_OFF_OVERRIDES = '//wireless/android/platform/testing/bettertogether/betocq:ble_scan_throttling_off_overrides'
+_BLE_SCAN_THROTTLING_ON_OVERRIDES = '//wireless/android/platform/testing/bettertogether/betocq:ble_scan_throttling_on_overrides'
+_INSTANT_CONNECTION_OFF_OVERRIDES = '//wireless/android/platform/testing/bettertogether/betocq:instant_connection_off_overrides'
+_INSTANT_CONNECTION_ON_OVERRIDES = '//wireless/android/platform/testing/bettertogether/betocq:instant_connection_on_overrides'
+_FLAG_SETUP_TEMPLATE_KEY = 'google3/java/com/google/android/libraries/phenotype/codegen/hermetic/setup_flags_template.sh'
+_GMS_PACKAGE = 'com.google.android.gms'
 
 WIFI_COUNTRYCODE_CONFIG_TIME_SEC = 3
 TOGGLE_AIRPLANE_MODE_WAIT_TIME_SEC = 2
@@ -279,11 +289,16 @@ def enable_airplane_mode(ad: android_device.AndroidDevice) -> None:
 
 
 def _do_enable_airplane_mode(ad: android_device.AndroidDevice) -> None:
-  if (ad.is_adb_root):
+  if ad.is_adb_root:
     ad.adb.shell(['settings', 'put', 'global', 'airplane_mode_on', '1'])
     ad.adb.shell([
-        'am', 'broadcast', '-a', 'android.intent.action.AIRPLANE_MODE', '--ez',
-        'state', 'true'
+        'am',
+        'broadcast',
+        '-a',
+        'android.intent.action.AIRPLANE_MODE',
+        '--ez',
+        'state',
+        'true',
     ])
   ad.adb.shell(['svc', 'wifi', 'disable'])
   ad.adb.shell(['svc', 'bluetooth', 'disable'])
@@ -303,224 +318,20 @@ def disable_airplane_mode(ad: android_device.AndroidDevice) -> None:
 
 
 def _do_disable_airplane_mode(ad: android_device.AndroidDevice) -> None:
-  if (ad.is_adb_root):
+  if ad.is_adb_root:
     ad.adb.shell(['settings', 'put', 'global', 'airplane_mode_on', '0'])
     ad.adb.shell([
-        'am', 'broadcast', '-a', 'android.intent.action.AIRPLANE_MODE', '--ez',
-        'state', 'false'
+        'am',
+        'broadcast',
+        '-a',
+        'android.intent.action.AIRPLANE_MODE',
+        '--ez',
+        'state',
+        'false',
     ])
   ad.adb.shell(['svc', 'wifi', 'enable'])
   ad.adb.shell(['svc', 'bluetooth', 'enable'])
   time.sleep(TOGGLE_AIRPLANE_MODE_WAIT_TIME_SEC)
-
-
-def check_if_ph_flag_committed(
-    ad: android_device.AndroidDevice,
-    pname: str,
-    flag_name: str,
-) -> bool:
-  """Check if P/H flag is committed.
-
-  Some devices don't support to check the flag with sqlite3. After the flag
-  check fails for the first time, it won't try it again.
-
-  Args:
-    ad: AndroidDevice, Mobly Android Device.
-    pname: The package name of the P/H flag.
-    flag_name: The name of the P/H flag.
-
-  Returns:
-    True if the P/H flag is committed.
-  """
-  if read_ph_flag_failed:
-    return False
-  flag_result = get_committed_ph_flags(ad, pname)
-  return flag_name in flag_result
-
-
-def get_committed_ph_flags(
-    ad: android_device.AndroidDevice,
-    pname: str,
-) -> str:
-  """Get committed P/H flags.
-
-  Some devices don't support to check the flag with sqlite3. After the flag
-  check fails for the first time, it won't try it again.
-
-  Args:
-    ad: AndroidDevice, Mobly Android Device.
-    pname: The package name of the P/H flag.
-
-  Returns:
-    List of committed P/H flags
-  """
-  global read_ph_flag_failed
-  if read_ph_flag_failed:
-    return ''
-  sql_str = (
-      'sqlite3 /data/data/com.google.android.gms/databases/phenotype.db'
-      ' "select name, quote(coalesce(intVal, boolVal, floatVal, stringVal,'
-      ' extensionVal)) from FlagOverrides where committed=1 AND'
-      f" packageName='{pname}';\""
-  )
-  try:
-    return ad.adb.shell(sql_str).decode('utf-8').strip()
-  except adb.AdbError:
-    read_ph_flag_failed = True
-    ad.log.exception('Failed to get committed P/H flags')
-  return ''
-
-
-def write_ph_flag(
-    ad: android_device.AndroidDevice,
-    pname: str,
-    flag_name: str,
-    flag_type: str,
-    flag_value: str,
-) -> None:
-  """Write P/H flag."""
-  ad.adb.shell(
-      'am broadcast -a "com.google.android.gms.phenotype.FLAG_OVERRIDE" '
-      f'--es package "{pname}" --es user "*" '
-      f'--esa flags "{flag_name}" '
-      f'--esa types "{flag_type}" --esa values "{flag_value}" '
-      'com.google.android.gms'
-  )
-  time.sleep(PH_FLAG_WRITE_WAIT_TIME_SEC)
-
-
-def check_and_try_to_write_ph_flag(
-    ad: android_device.AndroidDevice,
-    pname: str,
-    flag_name: str,
-    flag_type: str,
-    flag_value: str,
-) -> None:
-  """Check and try to enable the given flag on the given device."""
-  if(not ad.is_adb_root):
-    ad.log.info(
-        "Can't read or write P/H flag value in non-rooted device. Use Mobile"
-        ' Utility app to config instead.'
-    )
-    return
-
-  if check_if_ph_flag_committed(ad, pname, flag_name):
-    ad.log.info(f'{flag_name} is already committed.')
-    return
-  ad.log.info(f'write {flag_name}.')
-  write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-  if check_if_ph_flag_committed(ad, pname, flag_name):
-    ad.log.info(f'{flag_name} is configured successfully.')
-  else:
-    ad.log.info(f'failed to configure {flag_name}.')
-
-
-def enable_wifi_aware(ad: android_device.AndroidDevice) -> None:
-  """Enable wifi aware on the given device."""
-  pname = 'com.google.android.gms.nearby'
-  flag_name = 'mediums_supports_wifi_aware'
-  flag_type = 'boolean'
-  flag_value = 'true'
-
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-
-def enable_instant_connection(
-    ad: android_device.AndroidDevice, enable: bool = False
-) -> None:
-  """Enable instant connection on the given device."""
-  pname = 'com.google.android.gms.nearby'
-  flag_name = 'connections_support_instant_connection'
-  flag_type = 'boolean'
-  if enable:
-    flag_value = 'true'
-  else:
-    flag_value = 'false'
-
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-  flag_name = 'connections_support_instant_connection_sender'
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-
-def disable_wlan_deny_list(ad: android_device.AndroidDevice) -> None:
-  """Disable wlan deny list on the given device."""
-  pname = 'com.google.android.gms.nearby'
-  flag_name = 'wifi_lan_blacklist_verify_bssid_interval_hours'
-  flag_type = 'long'
-  flag_value = '0'
-
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-  flag_name = 'mediums_wifi_lan_temporary_blacklist_verify_bssid_interval_hours'
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-
-def disable_usb_medium(ad: android_device.AndroidDevice) -> None:
-  """Disable USB medium on the given device as it interferes ADB connection."""
-  pname = 'com.google.android.gms.nearby'
-  flag_name = 'mediums_supports_usb'
-  flag_type = 'boolean'
-  flag_value = 'false'
-
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-
-def disable_op_mode_check(ad: android_device.AndroidDevice) -> None:
-  """Disable get_usable_channel() op mode check on the given device."""
-  pname = 'com.google.android.gms.nearby'
-  flag_name = 'connections_check_op_mode_for_usable_channels'
-  flag_type = 'boolean'
-  flag_value = 'false'
-
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-
-def enable_ble_scan_throttling_during_2g_transfer(
-    ad: android_device.AndroidDevice, enable_ble_scan_throttling: bool = False
-) -> None:
-  """Enable BLE scan throttling during 2G transfer.
-  """
-
-  # The default values for the following parameters are 3 mins which are long
-  # enough for the performance test.
-  # mediums_ble_client_wifi_24_ghz_warming_up_duration
-  # fast_pair_wifi_24_ghz_warming_up_duration
-  # sharing_wifi_24_ghz_warming_up_duration
-
-  pname = 'com.google.android.gms.nearby'
-  flag_name = 'fast_pair_enable_connection_state_changed_listener'
-  flag_type = 'boolean'
-  flag_value = 'true' if enable_ble_scan_throttling else 'false'
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-  flag_name = 'sharing_enable_connection_state_changed_listener'
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-  flag_name = 'mediums_ble_client_enable_connection_state_changed_listener'
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-
-def disable_redaction(ad: android_device.AndroidDevice) -> None:
-  """Disable info log redaction on the given device."""
-  pname = 'com.google.android.gms'
-  flag_name = 'ClientLogging__enable_info_log_redaction'
-  flag_type = 'boolean'
-  flag_value = 'false'
-
-  check_and_try_to_write_ph_flag(ad, pname, flag_name, flag_type, flag_value)
-
-
-def force_flag_sync(ad: android_device.AndroidDevice) -> None:
-  """Force flag sync on the given device."""
-  ad.log.info('Force flag sync.')
-  ad.adb.shell(
-      'am broadcast -a "com.google.android.gms.gcm.ACTION_TRIGGER_TASK" -e'
-      ' component'
-      ' "com.google.android.gms/.phenotype.service.sync.PhenotypeConfigurator"'
-      ' -e tag "oneoff"'
-  )
 
 
 def restart_gms(ad: android_device.AndroidDevice) -> None:
@@ -534,7 +345,8 @@ def disable_gms_auto_updates(ad: android_device.AndroidDevice) -> None:
   if not ad.is_adb_root:
     ad.log.warning(
         'You should disable the play store auto updates manually on a'
-        'unrooted device, otherwise the test may be broken unexpected')
+        'unrooted device, otherwise the test may be broken unexpected'
+    )
   ad.log.info('try to disable GMS Auto Updates.')
   gms_auto_updates_util.GmsAutoUpdatesUtil(ad).disable_gms_auto_updates()
   time.sleep(_DISABLE_ENABLE_GMS_UPDATE_WAIT_TIME_SEC)
@@ -545,7 +357,8 @@ def enable_gms_auto_updates(ad: android_device.AndroidDevice) -> None:
   if not ad.is_adb_root:
     ad.log.warning(
         'You may enable the play store auto updates manually on a'
-        'unrooted device after test.')
+        'unrooted device after test.'
+    )
   ad.log.info('try to enable GMS Auto Updates.')
   gms_auto_updates_util.GmsAutoUpdatesUtil(ad).enable_gms_auto_updates()
   time.sleep(_DISABLE_ENABLE_GMS_UPDATE_WAIT_TIME_SEC)
@@ -593,7 +406,7 @@ def get_int_between_prefix_postfix(
     right_index = string.find(postfix)
   if left_index >= 0 and right_index > left_index:
     try:
-      return int(string[left_index + len(prefix): right_index].strip())
+      return int(string[left_index + len(prefix) : right_index].strip())
     except ValueError:
       return nc_constants.INVALID_INT
   return nc_constants.INVALID_INT
@@ -612,9 +425,7 @@ def dump_wifi_sta_status(ad: android_device.AndroidDevice) -> str:
 def dump_wifi_p2p_status(ad: android_device.AndroidDevice) -> str:
   """Dumps wifi p2p status on the given device."""
   try:
-    return (
-        ad.adb.shell('dumpsys wifip2p').decode('utf-8').strip()
-    )
+    return ad.adb.shell('dumpsys wifip2p').decode('utf-8').strip()
   except adb.AdbError:
     return ''
 
@@ -622,9 +433,7 @@ def dump_wifi_p2p_status(ad: android_device.AndroidDevice) -> str:
 def is_wifi_aware_available(ad: android_device.AndroidDevice) -> bool:
   """Checks if Aware is supported on the given device."""
   try:
-    return (
-        ad.nearby.wifiAwareIsAvailable()
-    )
+    return ad.nearby.wifiAwareIsAvailable()
   except Exception as e:  # pylint: disable=broad-except
     ad.log.info('Aware is not supported due to %s', e)
     return False
@@ -648,3 +457,52 @@ def get_wifi_sta_rssi(ad: android_device.AndroidDevice, ssid: str) -> int:
     return nc_constants.INVALID_RSSI
   except adb.AdbError:
     return nc_constants.INVALID_RSSI
+
+
+def _overrides_file_for_target(target: str) -> str:
+  """Returns the resource path for the given target."""
+  key = target.replace('//', 'google3/').replace(':', '/') + '_generated.txt'
+  return resources.GetResourceFilename(key)
+
+
+def _get_resource_contents(name: str) -> str:
+  """Returns the contents of the given resource."""
+  file_path = resources.GetResourceFilename(name)
+  with open(file_path, 'r') as f:
+    return f.read()
+
+
+def set_flags(
+    ad: android_device.AndroidDevice,
+    output_path: str,
+    enable_instant_connection: bool = False,
+    enable_2g_ble_scan_throttling: bool = False,
+):
+  """Sets flags on the given device."""
+  template_content = _get_resource_contents(_FLAG_SETUP_TEMPLATE_KEY)
+
+  def _install_overrides(target: str, merge_with_existing_overrides: bool):
+    ad.log.info('Installing hermetic overrides from %s', target)
+    hermetic_overrides_partner.install_hermetic_overrides(
+        ad,
+        _overrides_file_for_target(target),
+        output_path,
+        _GMS_PACKAGE,
+        template_content,
+        merge_with_existing_overrides=merge_with_existing_overrides,
+    )
+    restart_gms(ad)
+
+  _install_overrides(_DEFAULT_OVERRIDES, False)
+  _install_overrides(
+      _INSTANT_CONNECTION_ON_OVERRIDES
+      if enable_instant_connection
+      else _INSTANT_CONNECTION_OFF_OVERRIDES,
+      True,
+  )
+  _install_overrides(
+      _BLE_SCAN_THROTTLING_ON_OVERRIDES
+      if enable_2g_ble_scan_throttling
+      else _BLE_SCAN_THROTTLING_OFF_OVERRIDES,
+      True,
+  )

--- a/betocq/tests/iperf_utils_test.py
+++ b/betocq/tests/iperf_utils_test.py
@@ -24,7 +24,7 @@ class IPerfServerOnDeviceTest(unittest.TestCase):
   """Class that handles iperf3 server operations on device."""
 
   def test_get_ifconfig_aware_pixel(self):
-    """Test get_ifconfig_aware function.
+    """Test get_ifconfig_aware function for pixel devices.
 
     This test mocks the adb shell command function to return a sample
     ifconfig output from the pixel devices and asserts that the parsed ifconfig
@@ -64,10 +64,10 @@ class IPerfServerOnDeviceTest(unittest.TestCase):
     self.assertEqual(if_config_pixel, expected_ifconfig_pixel)
 
   def test_get_ifconfig_aware_non_pixel(self):
-    """Test get_ifconfig_aware function.
+    """Test get_ifconfig_aware function for non pixel devices.
 
     This test mocks the adb shell command function to return a sample
-    ifconfig output from the no pixel devices and asserts that the parsed
+    ifconfig output from the non pixel devices and asserts that the parsed
     ifconfig object matches the expected value.
     """
     mock_android_device_non_pixel = mock.Mock()
@@ -105,6 +105,172 @@ class IPerfServerOnDeviceTest(unittest.TestCase):
         mock_android_device_non_pixel
     )
     self.assertEqual(if_config_non_pixel, expected_ifconfig_non_pixel)
+
+  def test_get_ifconfig_wlan_pixel(self):
+    """Test get_ifconfig_wlan function for pixel devices.
+
+    This test mocks the adb shell command function to return a sample
+    ifconfig output from the pixel devices and asserts that the parsed
+    ifconfig object matches the expected value.
+    """
+    mock_android_device_pixel = mock.Mock()
+    mock_android_device_pixel.adb.shell.return_value = (
+        b"'wlan0','Link encap:Ethernet','HWaddr b2:33:73:81:ef:3e'"
+        b"'inet addr:192.168.1.205  Bcast:192.168.1.255  Mask:255.255.255.0'"
+        b"'inet6 addr: fe80::b033:73ff:fe81:ef3e/64 Scope: Link'"
+        b"'UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1'"
+        b"'RX packets:178287 errors:0 dropped:7 overruns:0 frame:0'"
+        b"'TX packets:206010 errors:0 dropped:38 overruns:0 carrier:0'"
+        b"'collisions:0 txqueuelen:1000'"
+        b"'RX bytes:117125843 TX bytes:173695970'"
+    )
+    expected_ifconfig_wlan_pixel = (
+        "'wlan0','Link encap:Ethernet','HWaddr b2:33:73:81:ef:3e'"
+        "'inet addr:192.168.1.205  Bcast:192.168.1.255  Mask:255.255.255.0'"
+        "'inet6 addr: fe80::b033:73ff:fe81:ef3e/64 Scope: Link'"
+        "'UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1'"
+        "'RX packets:178287 errors:0 dropped:7 overruns:0 frame:0'"
+        "'TX packets:206010 errors:0 dropped:38 overruns:0 carrier:0'"
+        "'collisions:0 txqueuelen:1000'"
+        "'RX bytes:117125843 TX bytes:173695970'"
+    )
+
+    if_config_wlan_pixel = iperf_utils.get_ifconfig_wlan(
+        mock_android_device_pixel
+    )
+
+    self.assertEqual(if_config_wlan_pixel, expected_ifconfig_wlan_pixel)
+
+  def test_get_ifconfig_wlan_non_pixel(self):
+    """Test get_ifconfig_wlan function for non pixel devices.
+
+    This test mocks the adb shell command function to return a sample
+    ifconfig output from the non pixel devices and asserts that the parsed
+    ifconfig object matches the expected value.
+    """
+    mock_android_device_non_pixel = mock.Mock()
+    mock_android_device_non_pixel.adb.shell.return_value = (
+        b"'wlan0','Link encap:Ethernet','HWaddr 62:5a:c2:b1:8c:0f','Driver "
+        b"cnss_pci','inet addr:192.168.1.132  Bcast:192.168.1.255"
+        b"Mask:255.255.255.0','inet6 addr: fe80::605a:c2ff:feb1:8c0f/64 Scope:"
+        b"Link','UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1'"
+        b"'RX packets:20635830 errors:0 dropped:56500 overruns:0 frame:0'"
+        b"'TX packets:1130354 errors:0 dropped:69 overruns:0 carrier:0'"
+        b"'collisions:0 txqueuelen:3000'"
+        b"'RX bytes:5530145535 TX bytes:238809451'"
+    )
+    expected_ifconfig_wlan_non_pixel = (
+        "'wlan0','Link encap:Ethernet','HWaddr 62:5a:c2:b1:8c:0f','Driver "
+        "cnss_pci','inet addr:192.168.1.132  Bcast:192.168.1.255"
+        "Mask:255.255.255.0','inet6 addr: fe80::605a:c2ff:feb1:8c0f/64 Scope:"
+        "Link','UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1'"
+        "'RX packets:20635830 errors:0 dropped:56500 overruns:0 frame:0'"
+        "'TX packets:1130354 errors:0 dropped:69 overruns:0 carrier:0'"
+        "'collisions:0 txqueuelen:3000'"
+        "'RX bytes:5530145535 TX bytes:238809451'"
+    )
+
+    if_config_wlan_non_pixel = iperf_utils.get_ifconfig_wlan(
+        mock_android_device_non_pixel
+    )
+
+    self.assertEqual(if_config_wlan_non_pixel, expected_ifconfig_wlan_non_pixel)
+
+  def test_get_ifconfig_p2p_pixel(self):
+    """Test get_ifconfig_p2p function for pixel devices.
+
+    This test mocks the adb shell command function to return a sample
+    ifconfig output from the pixel devices and asserts that the parsed
+    ifconfig object matches the expected value.
+    """
+    mock_android_device_pixel = mock.Mock()
+    mock_android_device_pixel.adb.shell.return_value = (
+        b"'p2p-wlan0-0','Link encap:Ethernet','HWaddr fa:1f:be:e5:8e:6a'"
+        b"'inet6 addr: fe80::f81f:beff:fee5:8e6a/64 Scope: Link'"
+        b"'UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1'"
+        b"'RX packets:23757 errors:0 dropped:0 overruns:0 frame:0'"
+        b"'TX packets:572413 errors:0 dropped:16 overruns:0 carrier:0'"
+        b"'collisions:0 txqueuelen:1000'"
+        b"'RX bytes:1710836 TX bytes:866080745'"
+    )
+    expected_ifconfig_p2p_pixel = (
+        "'p2p-wlan0-0','Link encap:Ethernet','HWaddr fa:1f:be:e5:8e:6a'"
+        "'inet6 addr: fe80::f81f:beff:fee5:8e6a/64 Scope: Link'"
+        "'UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1'"
+        "'RX packets:23757 errors:0 dropped:0 overruns:0 frame:0'"
+        "'TX packets:572413 errors:0 dropped:16 overruns:0 carrier:0'"
+        "'collisions:0 txqueuelen:1000'"
+        "'RX bytes:1710836 TX bytes:866080745'"
+    )
+
+    if_config_p2p_pixel = iperf_utils.get_ifconfig_p2p(
+        mock_android_device_pixel
+    )
+
+    self.assertEqual(if_config_p2p_pixel, expected_ifconfig_p2p_pixel)
+
+  def test_get_ifconfig_p2p_non_pixel(self):
+    """Test get_ifconfig_p2p function for non pixel devices.
+
+    This test mocks the adb shell command function to return a sample
+    ifconfig output from the non pixel devices and asserts that the parsed
+    ifconfig object matches the expected value.
+    """
+    mock_android_device_non_pixel = mock.Mock()
+    mock_android_device_non_pixel.adb.shell.return_value = (
+        b"'p2p-wlan0-0','Link encap:Ethernet','HWaddr"
+        b" f2:cd:31:fa:88:54','Drivercnss_pci','inet addr:192.168.49.1 "
+        b" Bcast:192.168.49.255  Mask:255.255.255.0','inet6 addr:"
+        b" fdc2:4a33:e9c::e(internal) Scope: Global','inet6 addr:"
+        b" fe80::f0cd:31ff:fefa:8854/64 Scope: Link','UP BROADCAST RUNNING"
+        b" MULTICAST  MTU:1500  Metric:1','RX packets:58075 errors:0 dropped:0"
+        b" overruns:0 frame:0','TX packets:2880 errors:0 dropped:0 overruns:0"
+        b" carrier:0','collisions:0 txqueuelen:3000','RX bytes:87826360 TX"
+        b" bytes:193840'"
+    )
+    expected_ifconfig_p2p_non_pixel = (
+        "'p2p-wlan0-0','Link encap:Ethernet','HWaddr"
+        " f2:cd:31:fa:88:54','Drivercnss_pci','inet addr:192.168.49.1 "
+        " Bcast:192.168.49.255  Mask:255.255.255.0','inet6 addr:"
+        " fdc2:4a33:e9c::e(internal) Scope: Global','inet6 addr:"
+        " fe80::f0cd:31ff:fefa:8854/64 Scope: Link','UP BROADCAST RUNNING"
+        " MULTICAST  MTU:1500  Metric:1','RX packets:58075 errors:0 dropped:0"
+        " overruns:0 frame:0','TX packets:2880 errors:0 dropped:0 overruns:0"
+        " carrier:0','collisions:0 txqueuelen:3000','RX bytes:87826360 TX"
+        " bytes:193840'"
+    )
+
+    if_config_p2p_non_pixel = iperf_utils.get_ifconfig_p2p(
+        mock_android_device_non_pixel
+    )
+
+    self.assertEqual(if_config_p2p_non_pixel, expected_ifconfig_p2p_non_pixel)
+
+  def test_get_group_owner_ipv4_addr(self):
+    """Test get_group_owner_addr function which returns ipv4 address."""
+    mock_android_device = mock.Mock()
+    mock_android_device.adb.shell.return_value = b" inet addr: 192.168.49.1"
+    expected_group_owner_ipv4_addr = "192.168.49.1"
+
+    group_owner_ipv4_addr = iperf_utils.get_group_owner_addr(
+        mock_android_device
+    )
+
+    self.assertEqual(group_owner_ipv4_addr, expected_group_owner_ipv4_addr)
+
+  def test_get_group_owner_ipv6_addr(self):
+    """Test get_group_owner_addr function which returns ipv6 address with link interface."""
+    mock_android_device = mock.Mock()
+    mock_android_device.adb.shell.return_value = (
+        b" inet6 addr: fe80::8cf5:c5ff:feae:2121/64-p2p-wlan0-0"
+    )
+    expected_group_owner_ipv6_addr = "fe80::8cf5:c5ff:feae:212164-p2p-wlan0-0"
+
+    group_owner_ipv6_addr = iperf_utils.get_group_owner_addr(
+        mock_android_device
+    )
+
+    self.assertEqual(group_owner_ipv6_addr, expected_group_owner_ipv6_addr)
 
 
 if __name__ == "__main__":

--- a/betocq/tests/iperf_utils_test.py
+++ b/betocq/tests/iperf_utils_test.py
@@ -1,0 +1,111 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Unittest for iperf_utils."""
+
+import unittest
+from unittest import mock
+
+from betocq import iperf_utils
+
+
+class IPerfServerOnDeviceTest(unittest.TestCase):
+  """Class that handles iperf3 server operations on device."""
+
+  def test_get_ifconfig_aware_pixel(self):
+    """Test get_ifconfig_aware function.
+
+    This test mocks the adb shell command function to return a sample
+    ifconfig output from the pixel devices and asserts that the parsed ifconfig
+    object matches the expected value.
+    """
+    mock_android_device_pixel = mock.Mock()
+
+    mock_android_device_pixel.adb.shell.return_value = (
+        b"'aware_nmi0','Link encap:Ethernet','HWaddr 2a:eb:2a:db:0c:cd','inet6"
+        b" addr: fe80::68a1:5aff:fe87:421a/64 Scope: Link','UP BROADCAST"
+        b" RUNNING MULTICAST  MTU:1500  Metric:1','RX packets:0 errors:0"
+        b" dropped:0 overruns:0 frame:0','TX packets:0 errors:0 dropped:0"
+        b" overruns:0 carrier:0','collisions:0 txqueuelen:1000','RX bytes:0 TX"
+        b" bytes:0','aware_data0','Link encap:Ethernet','HWaddr"
+        b" 46:0d:f7:cf:b6:e3','inet6 addr: fe80::440d:f7ff:fecf:b6e3/64 Scope:"
+        b" Link','UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1','RX"
+        b" packets:50667 errors:0 dropped:0 overruns:0 frame:0','TX"
+        b" packets:2199 errors:0 dropped:0 overruns:0 carrier:0','collisions:0"
+        b" txqueuelen:1000','RX bytes:75937716 TX bytes:189170'"
+    )
+
+    expected_ifconfig_pixel = (
+        "'aware_nmi0','Link encap:Ethernet','HWaddr 2a:eb:2a:db:0c:cd','inet6 "
+        "addr: fe80::68a1:5aff:fe87:421a/64 Scope: Link','UP BROADCAST RUNNING "
+        "MULTICAST  MTU:1500  Metric:1','RX packets:0 errors:0 dropped:0 "
+        "overruns:0 frame:0','TX packets:0 errors:0 dropped:0 overruns:0 "
+        "carrier:0','collisions:0 txqueuelen:1000','RX bytes:0 TX bytes:0',"
+        "'aware_data0','Link encap:Ethernet','HWaddr 46:0d:f7:cf:b6:e3',"
+        "'inet6 addr: fe80::440d:f7ff:fecf:b6e3/64 Scope: Link','UP BROADCAST "
+        "RUNNING MULTICAST  MTU:1500  Metric:1','RX packets:50667 errors:0 "
+        "dropped:0 overruns:0 frame:0','TX packets:2199 errors:0 dropped:0 "
+        "overruns:0 carrier:0','collisions:0 txqueuelen:1000','RX "
+        "bytes:75937716 TX bytes:189170'"
+    )
+
+    if_config_pixel = iperf_utils.get_ifconfig_aware(mock_android_device_pixel)
+    self.assertEqual(if_config_pixel, expected_ifconfig_pixel)
+
+  def test_get_ifconfig_aware_non_pixel(self):
+    """Test get_ifconfig_aware function.
+
+    This test mocks the adb shell command function to return a sample
+    ifconfig output from the no pixel devices and asserts that the parsed
+    ifconfig object matches the expected value.
+    """
+    mock_android_device_non_pixel = mock.Mock()
+
+    mock_android_device_non_pixel.adb.shell.return_value = (
+        b"'wifi-aware0','Link encap:Ethernet','HWaddr"
+        b" f2:cd:31:81:08:54','Driver cnss_pci','UP BROADCAST MULTICAST "
+        b" MTU:1500  Metric:1','RX packets:0 errors:0 dropped:0 overruns:0"
+        b" frame:0','TX packets:0 errors:0 dropped:0 overruns:0"
+        b" carrier:0','collisions:0 txqueuelen:3000','RX bytes:0 TX"
+        b" bytes:0','aware_data0','Link encap:Ethernet','HWaddr"
+        b" 02:2c:55:bd:73:ca','Driver cnss_pci','inet6 addr:"
+        b" fe80::2c:55ff:febd:73ca/64 Scope: Link','UP BROADCAST RUNNING"
+        b" MULTICAST  MTU:1500  Metric:1','RX packets:276314 errors:0 dropped:0"
+        b" overruns:0 frame:0','TX packets:12846 errors:0 dropped:0 overruns:0"
+        b" carrier:0','collisions:0 txqueuelen:3000','RX bytes:414058408 TX"
+        b" bytes:1104992'"
+    )
+
+    expected_ifconfig_non_pixel = (
+        "'wifi-aware0','Link encap:Ethernet','HWaddr f2:cd:31:81:08:54','Driver"
+        " cnss_pci','UP BROADCAST MULTICAST  MTU:1500  Metric:1','RX"
+        " packets:0 errors:0 dropped:0 overruns:0 frame:0','TX packets:0"
+        " errors:0 dropped:0 overruns:0 carrier:0','collisions:0"
+        " txqueuelen:3000','RX bytes:0 TX bytes:0','aware_data0','Link"
+        " encap:Ethernet','HWaddr 02:2c:55:bd:73:ca','Driver cnss_pci','inet6"
+        " addr: fe80::2c:55ff:febd:73ca/64 Scope: Link','UP BROADCAST RUNNING"
+        " MULTICAST  MTU:1500  Metric:1','RX packets:276314 errors:0 dropped:0"
+        " overruns:0 frame:0','TX packets:12846 errors:0 dropped:0 overruns:0"
+        " carrier:0','collisions:0 txqueuelen:3000','RX bytes:414058408 TX"
+        " bytes:1104992'"
+    )
+
+    if_config_non_pixel = iperf_utils.get_ifconfig_aware(
+        mock_android_device_non_pixel
+    )
+    self.assertEqual(if_config_non_pixel, expected_ifconfig_non_pixel)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
* Disable getUsableChannel() op mode check.
* Add BeToCQ-specific resources wrapper API.
* Use Mobly's native apk_utils to install APKs
* Add multi-payload test parameters and optimize multi-payload transfer test.
* Lower MCC Hotspot speed target.
* Disable payload ID sequence check for STREAM mode.
* Skip setting bluetooth HCI logs on unrooted devices.
* Add connection_medium into transfer_info and start to calculate medium_upgrade_latency after onBandwidthChanged callback for connection_medium.
* Enable Instant Connection on the sender.
* Update the triage tips for the WLAN upgrade failure.
* Fix a bug in Aware iperf test and add unit test.
* Unit test to validate utilities for running iperf on the devices
* Move BeToCQ to hermetic overrides. 