### PR TITLE
Include `synced_resource_data/` files as package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include betocq/snippets/*
+recursive-include betocq/snippets *
+recursive-include betocq/synced_resource_data *


### PR DESCRIPTION
Currently `importlib.resources` cannot detect files in `synced_resource_data/` due to it missing from `MANIFEST.in`