### PR TITLE
Generate a report file for APA from BeToCQ results

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 recursive-include betocq/snippets *
 recursive-include betocq/synced_resource_data *
-exclude betocq/tools/**

--- a/betocq/tools/local_mobly_runner.py
+++ b/betocq/tools/local_mobly_runner.py
@@ -26,6 +26,10 @@ Example:
     - Run a test binary with specific Android devices.
     local_mobly_runner test_suite_a -s DEV00001,DEV00002
 
+    - Run a test binary, and generate a report for Android Partner
+      Approvals.
+    local_mobly_runner test_suite_a --generate_report
+
 Please run `local_mobly_runner -h` for a full list of options.
 """
 

--- a/betocq/tools/local_mobly_runner.py
+++ b/betocq/tools/local_mobly_runner.py
@@ -36,10 +36,11 @@ Please run `local_mobly_runner -h` for a full list of options.
 import argparse
 import importlib.resources
 import os
+from pathlib import Path
 import shutil
 import subprocess
 import tempfile
-from pathlib import Path
+import time
 from typing import List, Optional
 
 import yaml
@@ -244,9 +245,11 @@ def main() -> None:
     config = args.config or _generate_mobly_config(serials)
 
     # Run the tests
+    start_time = int(time.time())
     latest_logs = _run_mobly_tests(
         args.mobly_bin, args.tests, config, args.test_bed, args.log_path
     )
+    end_time = int(time.time())
 
     # Clean up temporary dirs/files
     _clean_up()
@@ -254,7 +257,7 @@ def main() -> None:
     # Generate test report for submission to Android partner portal
     if args.generate_report:
         _padded_print('Generating test report.')
-        report_generator.generate_report(latest_logs)
+        report_generator.generate_report(latest_logs, start_time, end_time)
 
 
 if __name__ == '__main__':

--- a/betocq/tools/local_mobly_runner.py
+++ b/betocq/tools/local_mobly_runner.py
@@ -17,40 +17,32 @@
 """Script for running git-based Mobly tests locally.
 
 Example:
-    - Run a test binary from a Python wheel
-    local_mobly_runner.py -w my-test-0.1-py3-none-any.whl --bin test_suite_a
+    - Run a selected test binary
+    local_mobly_runner test_suite_a
 
-    - Run a test binary from a Python wheel. Install test APKs before running
-      the test.
-    local_mobly_runner.py -w my-test-0.1-py3-none-any.whl --bin test_suite_a -i
+    - Run a test binary. Install test APKs before running the test.
+    local_mobly_runner test_suite_a -i
 
-    - Run a test binary from a Python wheel, with specific Android devices.
-    local_mobly_runner.py -w my-test-0.1-py3-none-any.whl --bin test_suite_a -s DEV00001,DEV00002
+    - Run a test binary with specific Android devices.
+    local_mobly_runner test_suite_a -s DEV00001,DEV00002
 
-    - [Legacy] Run a list of zipped executable Mobly packages
-    local_mobly_runner.py -p test_pkg1,test_pkg2,test_pkg3
-
-
-Please run `local_mobly_runner.py -h` for a full list of options.
+Please run `local_mobly_runner -h` for a full list of options.
 """
 
 import argparse
-import json
+import importlib.resources
 import os
-from pathlib import Path
-import platform
 import shutil
 import subprocess
-import sys
 import tempfile
-from typing import List, Optional, Tuple
-import zipfile
+from pathlib import Path
+from typing import List, Optional
 
+import yaml
 
 _DEFAULT_MOBLY_LOGPATH = Path('/tmp/logs/mobly')
 _DEFAULT_TESTBED = 'LocalTestBed'
 
-_tempdirs = []
 _tempfiles = []
 
 
@@ -63,29 +55,11 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__)
-    group1 = parser.add_mutually_exclusive_group(required=True)
-    group1.add_argument(
-        '-p', '--packages',
+
+    parser.add_argument(
+        'mobly_bin',
         help=(
-            'A comma-delimited list of test packages to run. The packages '
-            'should be directly executable by the Python interpreter. If '
-            'the package includes a requirements.txt file, deps will '
-            'automatically be installed.'
-        )
-    )
-    group1.add_argument(
-        '-w', '--wheel',
-        help=(
-            'A Python wheel (.whl) containing one or more Mobly test scripts. '
-            'Does not support the --novenv option.'
-        )
-    )
-    group1.add_argument(
-        '-t',
-        '--test_paths',
-        help=(
-            'A comma-delimited list of test paths to run directly. Implies '
-            'the --novenv option.'
+            'Name of the installed Mobly binary to run.'
         ),
     )
 
@@ -94,8 +68,8 @@ def _parse_args() -> argparse.Namespace:
         '--install_apks',
         action='store_true',
         help=(
-            'Install all APKs contained inside the package to all specified'
-            ' devices. Does not support the -t option.'
+            'Install all APKs contained in package resource files to all '
+            'specified devices.'
         ),
     )
     parser.add_argument(
@@ -125,130 +99,13 @@ def _parse_args() -> argparse.Namespace:
         metavar='TEST_CLASS[.TEST_CASE]',
         help=(
             'A list of test classes and optional tests to execute within the '
-            'package or file. E.g. `--tests TestClassA TestClassB.test_b` '
+            'suite binary. E.g. `--tests TestClassA TestClassB.test_b` '
             'would run all of test class TestClassA, but only test_b in '
-            'TestClassB. This option cannot be used if multiple packages/test '
-            'paths are specified.'
+            'TestClassB.'
         ),
     )
-    parser.add_argument(
-        '--bin',
-        help=(
-            'Name of the binary to run in the installed wheel. Must be '
-            'specified alongside the --wheel option.'
-        ),
-    )
-    parser.add_argument(
-        '--novenv',
-        action='store_true',
-        help=(
-            "Run directly in the host's system Python, without setting up a "
-            'virtualenv.'
-        ),
-    )
-    args = parser.parse_args()
-    if args.wheel:
-        if args.novenv:
-            parser.error('Option --novenv cannot be used with --wheel.')
-        if not args.bin:
-            parser.error('Option --wheel requires --bin to be specified.')
-    if args.bin:
-        if not args.wheel:
-            parser.error('Option --bin requires --wheel to be specified.')
-    if args.install_apks and args.test_paths:
-        parser.error('Option --install_apks cannot be used with --test_paths.')
-    if args.tests is not None:
-        multiple_packages = (args.packages is not None
-                             and len(args.packages.split(',')) > 1)
-        multiple_test_paths = (args.test_paths is not None
-                               and len(args.test_paths.split(',')) > 1)
-        if multiple_packages or multiple_test_paths:
-            parser.error(
-                'Option --tests cannot be used if multiple --packages or '
-                '--test_paths are specified.'
-            )
 
-    args.novenv = args.novenv or (args.test_paths is not None)
-    return args
-
-
-def _extract_test_resources(
-        args: argparse.Namespace,
-) -> Tuple[List[str], List[str], List[str]]:
-    """Extract test resources from the given test package.
-
-    Args:
-      args: Parsed command-line args.
-
-    Returns:
-      Tuple of (mobly_bins, requirement_files, test_apks).
-    """
-    _padded_print('Resolving test resources.')
-    mobly_bins = []
-    requirements_files = []
-    test_apks = []
-    if args.test_paths:
-        mobly_bins.extend(args.test_paths.split(','))
-    elif args.packages or args.wheel:
-        packages = args.packages.split(',') if args.packages else [args.wheel]
-        unzip_root = tempfile.mkdtemp(prefix='mobly_unzip_')
-        _tempdirs.append(unzip_root)
-        for package in packages:
-            mobly_bins.append(os.path.abspath(package))
-            unzip_dir = os.path.join(unzip_root, os.path.basename(package))
-            print(f'Unzipping test package {package} to {unzip_dir}.')
-            os.makedirs(unzip_dir)
-            with zipfile.ZipFile(package) as zf:
-                zf.extractall(unzip_dir)
-            for root, _, files in os.walk(unzip_dir):
-                for file_name in files:
-                    path = os.path.join(root, file_name)
-                    if path.endswith('requirements.txt'):
-                        requirements_files.append(path)
-                    if path.endswith('.apk'):
-                        test_apks.append(path)
-    else:
-        print('No tests specified. Aborting.')
-        exit(1)
-    return mobly_bins, requirements_files, test_apks
-
-
-def _setup_virtualenv(
-        requirements_files: List[str],
-        wheel_file: Optional[str]
-) -> str:
-    """Creates a virtualenv and install dependencies into it.
-
-    Args:
-      requirements_files: List of paths of requirements.txt files.
-      wheel_file: A Mobly test package as an installable Python wheel.
-
-    Returns:
-      Path to the virtualenv's Python interpreter.
-    """
-    venv_dir = tempfile.mkdtemp(prefix='venv_')
-    _padded_print(f'Setting up virtualenv at {venv_dir}.')
-    subprocess.check_call([sys.executable, '-m', 'venv', venv_dir])
-    _tempdirs.append(venv_dir)
-    if platform.system() == 'Windows':
-        venv_executable = os.path.join(venv_dir, 'Scripts', 'python.exe')
-    else:
-        venv_executable = os.path.join(venv_dir, 'bin', 'python3')
-
-    # Install requirements
-    for requirements_file in requirements_files:
-        print(f'Installing dependencies from {requirements_file}.\n')
-        subprocess.check_call(
-            [venv_executable, '-m', 'pip', 'install', '-r', requirements_file]
-        )
-
-    # Install wheel
-    if wheel_file is not None:
-        print(f'Installing test wheel package {wheel_file}.\n')
-        subprocess.check_call(
-            [venv_executable, '-m', 'pip', 'install', wheel_file]
-        )
-    return venv_executable
+    return parser.parse_args()
 
 
 def _parse_adb_devices(lines: List[str]) -> List[str]:
@@ -265,15 +122,13 @@ def _parse_adb_devices(lines: List[str]) -> List[str]:
 
 
 def _install_apks(
-        apks: List[str],
         serials: Optional[List[str]] = None,
 ) -> None:
-    """Installs given APKS to specified devices.
+    """Installs snippet APKS to specified devices.
 
     If no serials specified, installs APKs on all attached devices.
 
     Args:
-      apks: List of paths to APKs.
       serials: List of device serials.
     """
     _padded_print('Installing test APKs.')
@@ -284,7 +139,8 @@ def _install_apks(
             ).decode('utf-8').strip().splitlines()
         )
         serials = _parse_adb_devices(adb_devices_out)
-    for apk in apks:
+    for apk in importlib.resources.files(
+            'betocq').joinpath('snippets').iterdir():
         for serial in serials:
             print(f'Installing {apk} on device {serial}.')
             subprocess.check_call(
@@ -315,47 +171,45 @@ def _generate_mobly_config(serials: Optional[List[str]] = None) -> str:
     _, config_path = tempfile.mkstemp(prefix='mobly_config_', suffix='.yaml')
     _padded_print(f'Generating Mobly config at {config_path}.')
     with open(config_path, 'w') as f:
-        json.dump(config, f)
+        yaml.safe_dump(config, f)
     _tempfiles.append(config_path)
     return config_path
 
 
 def _run_mobly_tests(
-        python_executable: Optional[str],
-        mobly_bins: List[str],
+        mobly_bin: str,
         tests: Optional[List[str]],
         config: str,
         test_bed: str,
         log_path: Optional[str]
-) -> None:
-    """Runs the Mobly tests with the specified binary and config."""
+) -> Path:
+    """Runs the Mobly tests with the specified binary and config.
+
+    Returns:
+        Path to the generated Mobly test log directory.
+    """
     env = os.environ.copy()
     base_log_path = _DEFAULT_MOBLY_LOGPATH
-    for mobly_bin in mobly_bins:
-        bin_name = os.path.basename(mobly_bin)
-        if log_path:
-            base_log_path = Path(log_path, bin_name)
-            env['MOBLY_LOGPATH'] = str(base_log_path)
-        cmd = [python_executable] if python_executable else []
-        cmd += [mobly_bin, '-c', config, '-tb', test_bed]
-        if tests is not None:
-            cmd.append('--tests')
-            cmd += tests
-        _padded_print(f'Running Mobly test {bin_name}.')
-        print(f'Command: {cmd}\n')
-        subprocess.run(cmd, env=env)
-        # Save a copy of the config in the log directory.
-        latest_logs = base_log_path.joinpath(test_bed, 'latest')
-        if latest_logs.is_dir():
-            shutil.copy2(config, latest_logs)
+    if log_path:
+        base_log_path = Path(log_path, mobly_bin)
+        env['MOBLY_LOGPATH'] = str(base_log_path)
+    cmd = [mobly_bin, '-c', config, '-tb', test_bed]
+    if tests is not None:
+        cmd.append('--tests')
+        cmd += tests
+    _padded_print(f'Running Mobly test {mobly_bin}.')
+    print(f'Command: {cmd}\n')
+    subprocess.run(cmd, env=env)
+    # Save a copy of the config in the log directory.
+    latest_logs = base_log_path.joinpath(test_bed, 'latest')
+    if latest_logs.is_dir():
+        shutil.copy2(config, latest_logs)
+    return latest_logs
 
 
 def _clean_up() -> None:
-    """Cleans up temporary directories and files."""
-    _padded_print('Cleaning up temporary directories/files.')
-    for td in _tempdirs:
-        shutil.rmtree(td, ignore_errors=True)
-    _tempdirs.clear()
+    """Cleans up temporary files."""
+    _padded_print('Cleaning up temporary files.')
     for tf in _tempfiles:
         os.remove(tf)
     _tempfiles.clear()
@@ -366,32 +220,15 @@ def main() -> None:
 
     serials = args.serials.split(',') if args.serials else None
 
-    # Extract test resources
-    mobly_bins, requirements_files, test_apks = _extract_test_resources(args)
-
     # Install test APKs, if necessary
     if args.install_apks:
-        _install_apks(test_apks, serials)
-
-    # Set up the Python virtualenv, if necessary
-    python_executable = None
-    if args.novenv:
-        if args.test_paths is not None:
-            python_executable = sys.executable
-    else:
-        python_executable = _setup_virtualenv(requirements_files, args.wheel)
-
-    if args.wheel:
-        mobly_bins = [
-            os.path.join(os.path.dirname(python_executable), args.bin)
-        ]
-        python_executable = None
+        _install_apks(serials)
 
     # Generate the Mobly config, if necessary
     config = args.config or _generate_mobly_config(serials)
 
     # Run the tests
-    _run_mobly_tests(python_executable, mobly_bins, args.tests, config,
+    _run_mobly_tests(args.mobly_bin, args.tests, config,
                      args.test_bed, args.log_path)
 
     # Clean up temporary dirs/files

--- a/betocq/tools/local_mobly_runner.py
+++ b/betocq/tools/local_mobly_runner.py
@@ -40,6 +40,9 @@ from typing import List, Optional
 
 import yaml
 
+from betocq.tools import report_generator
+
+
 _DEFAULT_MOBLY_LOGPATH = Path('/tmp/logs/mobly')
 _DEFAULT_TESTBED = 'LocalTestBed'
 
@@ -103,6 +106,15 @@ def _parse_args() -> argparse.Namespace:
             'would run all of test class TestClassA, but only test_b in '
             'TestClassB.'
         ),
+    )
+
+    parser.add_argument(
+        '-g',
+        '--generate_report',
+        action='store_true',
+        help=(
+            'Generate an Android Partner Approval report from the test results.'
+        )
     )
 
     return parser.parse_args()
@@ -228,11 +240,17 @@ def main() -> None:
     config = args.config or _generate_mobly_config(serials)
 
     # Run the tests
-    _run_mobly_tests(args.mobly_bin, args.tests, config,
-                     args.test_bed, args.log_path)
+    latest_logs = _run_mobly_tests(
+        args.mobly_bin, args.tests, config, args.test_bed, args.log_path
+    )
 
     # Clean up temporary dirs/files
     _clean_up()
+
+    # Generate test report for submission to Android partner portal
+    if args.generate_report:
+        _padded_print('Generating test report.')
+        report_generator.generate_report(latest_logs)
 
 
 if __name__ == '__main__':

--- a/betocq/tools/report_generator.py
+++ b/betocq/tools/report_generator.py
@@ -30,10 +30,10 @@ _RECORD_RESULT = records.TestResultEnums.RECORD_RESULT
 _RECORD_DETAILS = records.TestResultEnums.RECORD_DETAILS
 _RECORD_STACKTRACE = records.TestResultEnums.RECORD_STACKTRACE
 
-_TEST_RESULT_XML = 'test_result.xml'
-
 _MOBLY_SUMMARY_KEY_TYPE = 'Type'
 _MOBLY_SUMMARY_TYPE_RECORD = 'Record'
+
+_APA_TEST_RESULT_XML = 'test_result.xml'
 
 _APA_STATUS_PASS = 'pass'
 _APA_STATUS_WARNING = 'warning'
@@ -94,7 +94,7 @@ def _generate_test_result_xml(mobly_logs: Path, report_dir: Path) -> bool:
     mobly_summary = mobly_logs.joinpath(records.OUTPUT_FILE_SUMMARY)
     if not mobly_summary.is_file():
         print(
-            f'[WARNING] No BeToCQ summary found. Aborting {_TEST_RESULT_XML}'
+            f'[WARNING] No BeToCQ summary found. Aborting {_APA_TEST_RESULT_XML}'
             ' generation.'
         )
         return False
@@ -220,7 +220,7 @@ def _generate_test_result_xml(mobly_logs: Path, report_dir: Path) -> bool:
     test_result_xml = ElementTree.ElementTree(xml_root)
     ElementTree.indent(test_result_xml)
     os.makedirs(report_dir, exist_ok=True)
-    report_file = report_dir.joinpath(_TEST_RESULT_XML)
+    report_file = report_dir.joinpath(_APA_TEST_RESULT_XML)
     test_result_xml.write(
         report_file, encoding='utf-8', xml_declaration=True
     )

--- a/betocq/tools/report_generator.py
+++ b/betocq/tools/report_generator.py
@@ -1,0 +1,174 @@
+#  Copyright 2025 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Generates a BeToCQ test report for upload to APA."""
+import os
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+from betocq import nc_constants
+from betocq import version
+from mobly import records
+import yaml
+
+
+_RECORD_RESULT = records.TestResultEnums.RECORD_RESULT
+_RECORD_DETAILS = records.TestResultEnums.RECORD_DETAILS
+
+_TEST_RESULT_XML = 'test_result.xml'
+
+_MOBLY_SUMMARY_KEY_TYPE = 'Type'
+_MOBLY_SUMMARY_TYPE_RECORD = 'Record'
+
+_APA_STATUS_PASS = 'pass'
+_APA_STATUS_WARNING = 'warning'
+_APA_STATUS_ALERT = 'alert'
+_MOBLY_TO_APA_STATUS = {
+    'pass': _APA_STATUS_PASS,
+    'fail': _APA_STATUS_WARNING,
+    'skip': _APA_STATUS_PASS,
+    'error': _APA_STATUS_WARNING,
+}
+
+
+def _get_test_case_name_without_iteration_number(test_case_name: str):
+    """
+    Gets the base test case name of a repeated test case without the
+    iteration number.
+    """
+    parts = test_case_name.rsplit('_', 1)
+    if parts[1].isdigit():
+        return parts[0]
+    return test_case_name
+
+
+def _generate_test_result_xml(mobly_logs: Path, report_dir: Path) -> None:
+    """Generates a test_result.xml from the Mobly results."""
+    mobly_summary = mobly_logs.joinpath(records.OUTPUT_FILE_SUMMARY)
+    if not mobly_summary.is_file():
+        print('[WARNING] No BeToCQ summary found. Aborting report generation.')
+        return
+    results = {}
+    build_fingerprint = ''
+    setup_failure_classes = set()
+    with open(mobly_summary) as f:
+        summary = yaml.safe_load_all(f)
+        for entry in summary:
+            entry_type = entry[_MOBLY_SUMMARY_KEY_TYPE]
+            # Parse a test result record
+            if entry_type == records.TestSummaryEntryType.RECORD.value:
+                test_class = entry[records.TestResultEnums.RECORD_CLASS]
+                test_name = _get_test_case_name_without_iteration_number(
+                    entry[records.TestResultEnums.RECORD_NAME]
+                )
+                if test_class not in results:
+                    results[test_class] = {}
+                # Mark test class as aborted if we encounter a `setup_class`
+                # record (indicating failure).
+                if test_name == 'setup_class':
+                    setup_failure_classes.add(test_class)
+                    continue
+                # Replace the existing testcase results with the aggregated
+                # results from `teardown_class`.
+                if test_name == 'teardown_class':
+                    test_name = list(results[test_class].keys())[0]
+                results[test_class][test_name] = {
+                    key: entry[key] for key in (_RECORD_RESULT, _RECORD_DETAILS)
+                }
+                if test_class in setup_failure_classes:
+                    results[test_class][test_name][_RECORD_RESULT] = 'alert'
+            # Parse Android controller info
+            if entry_type == records.TestSummaryEntryType.CONTROLLER_INFO.value:
+                build_fingerprint = entry[
+                    records.ControllerInfoRecord.KEY_CONTROLLER_INFO
+                ][0].get('build_info', {}).get('build_fingerprint')
+
+    xml_root = ElementTree.Element(
+        'Result',
+        {
+            'suite_name': nc_constants.BETOCQ_SUITE_NAME,
+            'suite_version': version.TEST_SCRIPT_VERSION,
+        }
+    )
+    _ = ElementTree.SubElement(
+        xml_root, 'Build', {'build_fingerprint': build_fingerprint}
+    )
+    xml_summary = ElementTree.SubElement(xml_root, 'Summary')
+    xml_module = ElementTree.SubElement(
+        xml_root, 'Module',
+        {
+            'name': 'betocq_test_suite',
+        }
+    )
+    pass_count = 0
+    fail_count = 0
+    done = True
+    for test_class in results:
+        xml_test_case = ElementTree.SubElement(
+            xml_module, 'TestCase', {'name': test_class}
+        )
+        for test_name in results[test_class]:
+            test_case_entry = results[test_class][test_name]
+            result = test_case_entry[_RECORD_RESULT]
+            details = test_case_entry[_RECORD_DETAILS]
+            apa_status = _MOBLY_TO_APA_STATUS.get(
+                result.lower(), _APA_STATUS_ALERT
+            )
+            xml_test = ElementTree.SubElement(
+                xml_test_case, 'Test',
+                {
+                    'name': test_name,
+                    'result': apa_status}
+            )
+            if apa_status == _APA_STATUS_PASS:
+                pass_count += 1
+            elif apa_status == _APA_STATUS_WARNING:
+                _ = ElementTree.SubElement(
+                    xml_test, 'Failure',
+                    {'message': f'[WARNING] {details}'}
+                )
+            else:
+                done = False
+                fail_count += 1
+                _ = ElementTree.SubElement(
+                    xml_test, 'Failure',
+                    {'message': f'[SETUP ERROR] {details}'}
+                )
+    xml_summary.set('pass', str(pass_count))
+    xml_summary.set('failed', str(fail_count))
+    # TODO: support execution of more than one module (BeToCQ suite)
+    xml_summary.set('modules_done', '1' if done else '0')
+    xml_summary.set('modules_total', '1')
+
+    xml_module.set('done', str(done).lower())
+    xml_module.set('pass', str(pass_count))
+
+    test_result_xml = ElementTree.ElementTree(xml_root)
+    ElementTree.indent(test_result_xml)
+    os.makedirs(report_dir, exist_ok=True)
+    report_file = report_dir.joinpath(_TEST_RESULT_XML)
+    test_result_xml.write(
+        report_file, encoding='utf-8', xml_declaration=True
+    )
+
+    print(f'Report created in {report_file}')
+
+
+if __name__ == '__main__':
+    mobly_dir = Path(sys.argv[1]).expanduser()
+    _generate_test_result_xml(
+        mobly_dir,
+        Path('/tmp/report_generator/').joinpath(mobly_dir.name)
+    )

--- a/betocq/tools/report_generator.py
+++ b/betocq/tools/report_generator.py
@@ -82,15 +82,22 @@ def _get_test_case_name_without_iteration_number(test_case_name: str) -> str:
     return test_case_name
 
 
-def _generate_test_result_xml(mobly_logs: Path, report_dir: Path) -> None:
-    """Generates a test_result.xml from the Mobly results."""
+def _generate_test_result_xml(mobly_logs: Path, report_dir: Path) -> bool:
+    """Generates a test_result.xml from the Mobly results.
+
+    Args:
+        mobly_logs: The base Mobly log directory (containing test_summary.yaml)
+        report_dir: The target directory to save the test_result.xml
+
+    Returns: True if the operation succeeds.
+    """
     mobly_summary = mobly_logs.joinpath(records.OUTPUT_FILE_SUMMARY)
     if not mobly_summary.is_file():
         print(
-            '[WARNING] No BeToCQ summary found. Aborting test_result.xml'
+            f'[WARNING] No BeToCQ summary found. Aborting {_TEST_RESULT_XML}'
             ' generation.'
         )
-        return
+        return False
     results = {}
     build_info = {}
     setup_failure_classes = set()
@@ -217,6 +224,7 @@ def _generate_test_result_xml(mobly_logs: Path, report_dir: Path) -> None:
     test_result_xml.write(
         report_file, encoding='utf-8', xml_declaration=True
     )
+    return True
 
 
 def generate_report(mobly_logs: Path) -> None:
@@ -228,7 +236,8 @@ def generate_report(mobly_logs: Path) -> None:
     report_dir = Path(tempfile.mkdtemp())
     report_base_files = report_dir.joinpath('base_files')
 
-    _generate_test_result_xml(mobly_logs, report_base_files)
+    if not _generate_test_result_xml(mobly_logs, report_base_files):
+        return
 
     zip_path = report_dir.joinpath('report.zip')
     with zipfile.ZipFile(zip_path, 'w') as zip_file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,12 @@ requires-python = ">=3.11"
 dependencies = [
   "mobly",
   "mobly-wifi",
+  "pyyaml",
 ]
 
 [project.scripts]
 betocq_test_suite = "betocq.betocq_test_suite:main"
+local_mobly_runner = "betocq.tools.local_mobly_runner:main"
 
 [project.urls]
 Homepage = "https://github.com/android/betocq"


### PR DESCRIPTION
This operation can be enabled by adding a `--generate_report` flag to the `local_mobly_runner` command.

TODO:
- ~~Clean up logic~~
- Unit tests
- ~~Integrate into local_mobly_runner~~

-------

The `local_mobly_runner` is also updated to run as a script within the BeToCQ installation, instead of a standalone .py file.

