### PR TITLE
Add dep to mobly-android-partner-tools to integrate the Mobly CLIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "mobly",
+  "mobly-android-partner-tools",
   "mobly-wifi",
 ]
 


### PR DESCRIPTION
With this library users can now access both the local runner and results uploader with just a single installation of BeToCQ. (no separate download required)