### PR TITLE
Modify github only configs after synchronizing latest internal changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,15 @@ description = "Better Together Connectivity Quality test suite."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "mobly",
+  "mobly==1.13",
   "mobly-android-partner-tools",
-  "mobly-wifi",
+  "mobly-wifi==1.2.0",
 ]
 
 [project.scripts]
-betocq_test_suite = "betocq.betocq_test_suite:main"
-betocq_auto_test_suite = "betocq.betocq_android_auto_test_suite:main"
+betocq_test_suite = "betocq.nearby_connection.betocq_test_suite:main"
+betocq_auto_test_suite = "betocq.nearby_connection.betocq_android_auto_test_suite:main"
+
 
 [project.urls]
 Homepage = "https://github.com/android/betocq"


### PR DESCRIPTION
This PR must be submitted after PR #51.

Changes:
1. Updated `project.scripts` paths due to relocated test suite source files.
2. Pinned `mobly` and `mobly-wifi` versions to prevent any breakage caused by dependency releases. Also, mobly >= 1.13 is now required.